### PR TITLE
Added possibility to define output models for endpoints

### DIFF
--- a/docs/going_further/advanced_features.md
+++ b/docs/going_further/advanced_features.md
@@ -70,3 +70,62 @@ This could be done easily by overriding these two functions in the **GenericPred
 ```python hl_lines="28 29 30 31 32 33 34 35 36 37 38"
 {!./serveml/predictions.py!}
 ```
+
+## Defining outputs for **/predict** and **/feedback**
+
+By default, we do not define output models for both **/predict** and **/feedback** endpoints.
+
+But you can specify them if you wish to. Here is how : 
+
+````python
+from typing import List
+
+from serveml.api import ApiBuilder
+from serveml.inputs import BasicInput
+from serveml.loader import load_mlflow_model
+from serveml.outputs import BasicFeedbackOutput, BasicPredictOutput
+from serveml.predictions import GenericPrediction
+
+
+# load model
+model = load_mlflow_model(
+    # MlFlow model path
+    'models:/sklearn_model/1',
+    # MlFlow Tracking URI
+    'http://localhost:5000',
+)
+
+
+# Implement deserializer for input data
+class WineComposition(BasicInput):
+    alcohol: float
+    chlorides: float
+    citric_acid: float
+    density: float
+    fixed_acidity: float
+    free_sulfur_dioxide: int
+    pH: float
+    residual_sugar: float
+    sulphates: float
+    total_sulfur_dioxide: int
+    volatile_acidity: int
+
+
+# Implement deserializer for /predict output data
+class WineQuality(BasicPredictOutput):
+    result: List[float]
+
+
+# Implement deserializer for /predict output data
+class WineFeedbackOutput(BasicFeedbackOutput):
+    status: bool
+
+
+# implement application
+app = ApiBuilder(
+    GenericPrediction(model),
+    WineComposition,
+    predict_output_class=WineQuality,
+    feedback_output_class=WineFeedbackOutput
+).build_api()
+````

--- a/examples/training/keras.py
+++ b/examples/training/keras.py
@@ -14,6 +14,8 @@ from keras.preprocessing.text import Tokenizer
 # to automatically log metrics and parameters to MLflow.
 import mlflow.keras
 
+mlflow.set_tracking_uri("http://localhost:5000")
+
 mlflow.keras.autolog()
 
 max_words = 1000

--- a/examples/training/prophet.py
+++ b/examples/training/prophet.py
@@ -70,6 +70,8 @@ if __name__ == "__main__":
             e,
         )
 
+    mlflow.set_tracking_uri("http://localhost:5000")
+
     experiment_name = "test_prophet"
     if mlflow.get_experiment_by_name(experiment_name) is None:
         mlflow.create_experiment(experiment_name)

--- a/examples/training/pytorch.py
+++ b/examples/training/pytorch.py
@@ -44,6 +44,8 @@ for hv in [4.0, 5.0, 6.0]:
     hour_var = torch.Tensor([[hv]])
     y_pred = model(hour_var)
 
+mlflow.set_tracking_uri("http://localhost:5000")
+
 experiment_name = "test_pytorch"
 if mlflow.get_experiment_by_name(experiment_name) is None:
     mlflow.create_experiment(experiment_name)

--- a/examples/training/tensorflow.py
+++ b/examples/training/tensorflow.py
@@ -73,6 +73,8 @@ def eval_input_fn(features, labels, batch_size):
     return dataset
 
 
+mlflow.set_tracking_uri("http://localhost:5000")
+
 # Enable auto-logging to MLflow to capture TensorBoard metrics.
 mlflow.tensorflow.autolog()
 

--- a/examples/training/xgboost.py
+++ b/examples/training/xgboost.py
@@ -46,6 +46,9 @@ def main():
     dtest = xgb.DMatrix(X_test, label=y_test)
 
     experiment_name = "test_xgboost"
+
+    mlflow.set_tracking_uri("http://localhost:5000")
+
     if mlflow.get_experiment_by_name(experiment_name) is None:
         mlflow.create_experiment(experiment_name)
 

--- a/serveml/inputs.py
+++ b/serveml/inputs.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel as BasicInput
 
 
-class FeedbackInput(BasicInput):
+class BasicFeedbackInput(BasicInput):
     """
     Basic input validator for feedbacks
     """

--- a/serveml/outputs.py
+++ b/serveml/outputs.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel as BasicInput
+
+
+class BasicPredictOutput(BasicInput):
+    """
+    Basic input validator for feedbacks
+    """
+
+    request_id: str
+
+
+class BasicFeedbackOutput(BasicInput):
+    """
+    Basic input validator for feedbacks
+    """
+
+    status: bool
+    request_id: str

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -2,27 +2,27 @@ import unittest
 
 from pydantic.error_wrappers import ValidationError
 
-from serveml.inputs import BasicFeedbackInput
+from serveml.outputs import BasicFeedbackOutput
 
 
-class TestInputs(unittest.TestCase):
-    def test_parsing_good_input(self):
+class TestOutputs(unittest.TestCase):
+    def test_parsing_good_output(self):
         feedback_input = {"request_id": "coconut", "status": True}
-        feedback_object = BasicFeedbackInput(**feedback_input)
+        feedback_object = BasicFeedbackOutput(**feedback_input)
         self.assertEqual(feedback_object.request_id, "coconut")
         self.assertEqual(feedback_object.status, True)
 
-    def test_parsing_input_with_wrong_type(self):
+    def test_parsing_output_with_wrong_type(self):
         feedback_input = {"request_id": "coconut", "status": "coconut"}
         with self.assertRaises(ValidationError):
-            BasicFeedbackInput(**feedback_input)
+            BasicFeedbackOutput(**feedback_input)
 
-    def test_parsing_input_with_wrong_additional_inputs(self):
+    def test_parsing_output_with_wrong_additional_inputs(self):
         feedback_input = {
             "request_id": "coconut",
             "status": True,
             "awesome": True,
         }
-        feedback = BasicFeedbackInput(**feedback_input)
-        expected_keys = {"request_id", "status", "expected_result"}
+        feedback = BasicFeedbackOutput(**feedback_input)
+        expected_keys = {"request_id", "status"}
         self.assertEqual(expected_keys, feedback.dict().keys())

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import pandas as pd
 
-from serveml.inputs import BasicInput, FeedbackInput
+from serveml.inputs import BasicInput, BasicFeedbackInput
 from serveml.loader import load_mlflow_model
 from serveml.predictions import GenericPrediction
 from serveml.utils import dict_to_pandas
@@ -33,7 +33,7 @@ class TestGenericPrediction(unittest.TestCase):
             "status": True,
             "expected_result": "coco",
         }
-        result = self.prediction._transform_input(FeedbackInput(**item))
+        result = self.prediction._transform_input(BasicFeedbackInput(**item))
         self.assertTrue(result.equals(dict_to_pandas(item)))
 
     def test__apply_model(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import unittest
 
 import pandas as pd
 
-from serveml.inputs import FeedbackInput
+from serveml.inputs import BasicFeedbackInput
 from serveml.utils import (
     dict_to_pandas,
     pandas_to_dict,
@@ -23,7 +23,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(pandas_to_dict(df), [item])
 
     def test_pydantic_model_to_pandas(self):
-        feedback = FeedbackInput(status=True, request_id="coconut")
+        feedback = BasicFeedbackInput(status=True, request_id="coconut")
         result = pydantic_model_to_pandas(feedback)
         item = {
             "request_id": "coconut",


### PR DESCRIPTION
This PR adds the possibility to define output models for **/predict** and **/feedback** endpoints

I added the documentation on how to do that